### PR TITLE
메인페이지에 사이트에서 제공하는 콘텐츠 목록 추가했습니다!

### DIFF
--- a/controllers/homeController.js
+++ b/controllers/homeController.js
@@ -1,5 +1,16 @@
-const db = require("../db");
+const db = require("../models"),
+	Article = db.article;
 
-exports.showMainPage = (req, res) => {
-	res.render('home');
+exports.showMainPage = async (req, res) => {
+	try {
+		data = await Article.findAll({
+			limit: 3,
+			order: [['created_at', 'DESC']]
+		});
+		res.render('home', { article: data });
+	} catch (err) {
+		res.status(500).send({
+			message: err.message
+		});
+	}
 };

--- a/public/style/home.css
+++ b/public/style/home.css
@@ -1,0 +1,81 @@
+.our-contents {
+  padding: 2rem;
+}
+.contents-title-box {
+  display: flex;
+  align-items: center;
+  padding: 0.5rem 1.5rem;
+  border: 1px solid #5A5A5A;
+  border-radius: 5px;
+  margin-bottom: 1rem;
+  color: #F6F6F6;
+}
+.contents-title {
+  position: relative;
+  left: 0%;
+  font-size: 1.8rem;
+  font-weight: bold;
+  color: black;
+}
+.contents-link {
+  position: relative;
+  left: 73%;
+  font-size: 1rem;
+  color: #5A5A5A;
+  text-decoration: none;
+}
+.contents-boxes {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.contents-box {
+  flex: 1;
+  height: 350px;
+  padding: 1rem;
+  border: 1px solid #5A5A5A;
+  border-radius: 5px;
+  background-color: white;
+}
+.contents-box > h3 {
+  text-align: center;
+  font-size: 1.5rem;
+  margin-bottom: 0.5rem;
+}
+.contents-meta {
+  text-align: center;
+  font-size: 1rem;
+  margin-bottom: 1rem;
+}
+.contents-text {
+  width: 90%;
+  height: 50%;
+  margin-left: 1rem;
+  margin-right: 1rem;
+  margin-bottom: 1rem;
+  text-align: justify;
+  overflow: hidden;
+}
+.fact-buttons {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.button-fact {
+  padding: 0.5rem 1.5rem;
+  margin-right: 1rem;
+  background-color: #6FC4B5;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  text-decoration: none;
+}
+.button-nfact {
+  padding: 0.5rem 1.5rem;
+  margin-left: 1rem;
+  background-color: #757575;
+  color: white;
+  border: none;
+  border-radius: 5px;
+  text-decoration: none;
+}

--- a/public/style/layout.css
+++ b/public/style/layout.css
@@ -39,10 +39,6 @@ body {
 	border: 1px solid black;
 	border-radius: 5px;
 }
-.account-page > a {
-	color: black;
-	text-decoration: none;
-}
 .logout {
 	position: relative;
 	left: 65%;
@@ -53,10 +49,6 @@ body {
 	border-radius: 5px;
 	text-decoration: none;
 }
-.logout > a {
-	color: white;
-	text-decoration: none;
-}
 .login {
 	position: relative;
 	left: 75.7%;
@@ -65,9 +57,5 @@ body {
 	color: white;
 	border: none;
 	border-radius: 5px;
-	text-decoration: none;
-}
-.login > a {
-	color: white;
 	text-decoration: none;
 }

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -1,3 +1,46 @@
 <div class="home">
-	<h1>main page</h1>
+<div class="our-contents">
+  <div class="contents-title-box">
+    <span class="contents-title">
+      📰 최신 이슈
+    </span>
+    <a class="contents-link" href="/articles">
+      최신 이슈 더보기 →
+    </a>
+  </div>
+  <div class="contents-boxes">
+
+    <span class="contents-box">
+      <h3><%= article[0].title %></h3>
+      <p class="contents-meta"><%= article[0].press %> | <%= article[0].author %> | <%= new Date(article[0].created_at).toLocaleDateString('ko-KR') %></p>
+      <p class="contents-text"><%= article[0].content %></p>
+      <span class="fact-buttons">
+        <a class="button-fact" href="/articles/<%= article[0].article_id %>">팩트다</a>
+        <a class="button-nfact" href="/articles/<%= article[0].article_id %>">아니다</a>
+      </span>
+    </span>
+
+
+    <span class="contents-box">
+      <h3><%= article[1].title %></h3>
+      <p class="contents-meta"><%= article[1].press %> | <%= article[1].author %> | <%= new Date(article[1].created_at).toLocaleDateString('ko-KR') %></p>
+      <p class="contents-text"><%= article[1].content %></p>
+      <span class="fact-buttons">
+        <a class="button-fact" href="/articles/<%= article[1].article_id %>">팩트다</a>
+        <a class="button-nfact" href="/articles/<%= article[1].article_id %>">아니다</a>
+      </span>
+    </span>
+    
+    <span class="contents-box">
+      <h3><%= article[2].title %></h3>
+      <p class="contents-meta"><%= article[2].press %> | <%= article[2].author %> | <%= new Date(article[2].created_at).toLocaleDateString('ko-KR') %></p>
+      <p class="contents-text"><%= article[2].content %></p>
+      <span class="fact-buttons">
+        <a class="button-fact" href="/articles/<%= article[2].article_id %>">팩트다</a>
+        <a class="button-nfact" href="/articles/<%= article[2].article_id %>">아니다</a>
+      </span>
+    </span>
+
+  </div>
+</div>
 </div>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -9,28 +9,27 @@
   <link rel="stylesheet" href="/style/layout.css">
   <link rel="stylesheet" href="/style/article.css">
   <link rel="stylesheet" href="/style/articleList.css">
+  <link rel="stylesheet" href="/style/home.css">
 </head>
 
 <body>
   <nav class="navigation">
     <h1 class="logo">MirrorLit</h1>
-      <span class="notification">
-        <a href="#"><img src="/images/notification.png" width="35"></a>
-      </span>
-      <span class="account-page">
-        <a href="#">마이페이지</a>
-      </span>
-      <span class="logout">
-        <a href="#">로그아웃</a>
-      </span>
-    <span class="login">
-      <a href="#">로그인</a>
-    </span>
-
+    <a class="notification" href="#">
+      <img src="/images/notification.png" width="35">
+    </a>
+    <a class="account-page" href="#">
+      마이페이지
+    </a>
+    <a class="logout" href="#">
+      로그아웃
+    </a>
+    <a class="login" href="#">
+      로그인
+    </a>
   </nav>
 
   <%- body %>
 
 </body>
-
 </html>


### PR DESCRIPTION
![스크린샷 2025-05-13 014752](https://github.com/user-attachments/assets/226cf43b-6bf8-45b3-8eda-f52f83cb04e0)

메인페이지에 사이트에서 제공하는 콘텐츠 목록을 추가했습니다.

현재는 '최신 이슈' 콘텐츠만 존재하기에, 해당 내용만 넣어두었습니다.
최신 이슈의 기사 중에서 최근에 등록된 기사 3개를 가져와서 보여주는 기능입니다.

1. '최신 이슈 더보기 →'를 클릭하면 기사 목록 페이지로 이동하고
2. '팩트다' 또는 '아니다' 버튼을 클릭하면 해당 기사의 상세 페이지로 이동됩니다.

2번의 경우, 이전 회의 때 언급되었던 네이버 지식in을 참고해서 디자인했는데요.
혹시 더 좋은 형태가 있다면 제안주신대로 수정해 두겠습니다.

확인 감사합니다  :)