### PR TITLE
메인페이지 프론트를 조금 바꿨습니다

### DIFF
--- a/public/style/home.css
+++ b/public/style/home.css
@@ -9,6 +9,7 @@
   border-radius: 5px;
   margin-bottom: 1rem;
   color: #F6F6F6;
+  background-color:#F6F6F6; 
 }
 .contents-title {
   position: relative;
@@ -16,12 +17,6 @@
   font-size: 1.8rem;
   font-weight: bold;
   color: black;
-}
-.contents-link {
-  position: relative;
-  left: 73%;
-  font-size: 1rem;
-  color: #5A5A5A;
   text-decoration: none;
 }
 .contents-boxes {
@@ -31,15 +26,19 @@
 }
 .contents-box {
   flex: 1;
-  height: 350px;
+  height: 300px;
   padding: 1rem;
   border: 1px solid #5A5A5A;
   border-radius: 5px;
   background-color: white;
 }
-.contents-box > h3 {
-  text-align: center;
+.contents-box > a {
+  display: flex;
+  justify-content: center;
   font-size: 1.5rem;
+  font-weight: bold;
+  color: black;
+  text-decoration: none;
   margin-bottom: 0.5rem;
 }
 .contents-meta {
@@ -49,7 +48,7 @@
 }
 .contents-text {
   width: 90%;
-  height: 50%;
+  height: 57%;
   margin-left: 1rem;
   margin-right: 1rem;
   margin-bottom: 1rem;

--- a/public/style/layout.css
+++ b/public/style/layout.css
@@ -23,6 +23,8 @@ body {
 	left: 3%;
 	font-size: 2rem;
 	font-weight: bold;
+	text-decoration: none;
+	color: black;
 }
 .notification {
 	margin-top: 1px;

--- a/views/home.ejs
+++ b/views/home.ejs
@@ -1,44 +1,29 @@
 <div class="home">
 <div class="our-contents">
   <div class="contents-title-box">
-    <span class="contents-title">
+    <a class="contents-title" href="/articles">
       📰 최신 이슈
-    </span>
-    <a class="contents-link" href="/articles">
-      최신 이슈 더보기 →
     </a>
   </div>
   <div class="contents-boxes">
 
     <span class="contents-box">
-      <h3><%= article[0].title %></h3>
+      <a href="/articles/<%= article[0].article_id %>"><%= article[0].title %></a>
       <p class="contents-meta"><%= article[0].press %> | <%= article[0].author %> | <%= new Date(article[0].created_at).toLocaleDateString('ko-KR') %></p>
       <p class="contents-text"><%= article[0].content %></p>
-      <span class="fact-buttons">
-        <a class="button-fact" href="/articles/<%= article[0].article_id %>">팩트다</a>
-        <a class="button-nfact" href="/articles/<%= article[0].article_id %>">아니다</a>
-      </span>
     </span>
 
 
     <span class="contents-box">
-      <h3><%= article[1].title %></h3>
+      <a href="/articles/<%= article[1].article_id %>"><%= article[1].title %></a>
       <p class="contents-meta"><%= article[1].press %> | <%= article[1].author %> | <%= new Date(article[1].created_at).toLocaleDateString('ko-KR') %></p>
       <p class="contents-text"><%= article[1].content %></p>
-      <span class="fact-buttons">
-        <a class="button-fact" href="/articles/<%= article[1].article_id %>">팩트다</a>
-        <a class="button-nfact" href="/articles/<%= article[1].article_id %>">아니다</a>
-      </span>
     </span>
     
     <span class="contents-box">
-      <h3><%= article[2].title %></h3>
+      <a href="/articles/<%= article[2].article_id %>"><%= article[2].title %></a>
       <p class="contents-meta"><%= article[2].press %> | <%= article[2].author %> | <%= new Date(article[2].created_at).toLocaleDateString('ko-KR') %></p>
       <p class="contents-text"><%= article[2].content %></p>
-      <span class="fact-buttons">
-        <a class="button-fact" href="/articles/<%= article[2].article_id %>">팩트다</a>
-        <a class="button-nfact" href="/articles/<%= article[2].article_id %>">아니다</a>
-      </span>
     </span>
 
   </div>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -14,7 +14,7 @@
 
 <body>
   <nav class="navigation">
-    <h1 class="logo">MirrorLit</h1>
+    <a class="logo" href="/home">MirrorLit</a>
     <a class="notification" href="#">
       <img src="/images/notification.png" width="35">
     </a>


### PR DESCRIPTION
![스크린샷 2025-05-13 232414](https://github.com/user-attachments/assets/c7eaa00a-aebe-4261-b1df-f4991fba7327)

막상 merge하고 나니까 지금 바꿔두는게 나을 것 같아서 아주 약간 수정했습니다..

1. 팩트다/아니다 버튼을 없애고, 기사 제목을 눌러서 기사 상세 페이지로 이동하도록 바꿨습니다.
2. '기사 더보기'를 없애고, '최신 이슈' 타이틀 클릭해서 기사 목록 페이지로 이동하도록 바꿨습니다.
3. 로고 클릭하면 '/home'으로 이동하도록 했습니다.

정말 사소한 부분이라 바로 merge 하려 합니다. 확인 감사합니다..!