### PR TITLE
Update commentAlterHandler.js

### DIFF
--- a/controllers/commentAlterHandler.js
+++ b/controllers/commentAlterHandler.js
@@ -1,10 +1,18 @@
 const db = require("../models"),
-  CommentHistory = db.comment_history,
-  CommentAlert = db.comment_alert;
+  CommentHistory = db.CommentHistory,
+  CommentAlert = db.CommentAlert;
 
 exports.handleCommentNotification = async (article_id, comment_id, user_id) => {
   try {
-    await CommentHistory.create({ article_id, comment_id, user_id });
+    // 해당 사용자의 댓글 기록이 있는지 확인
+    const existing = await CommentHistory.findOne({
+      where: { article_id, user_id }
+    });
+
+    // 기록이 없으면 추가
+    if (!existing) {
+      await CommentHistory.create({ article_id, comment_id, user_id });
+    }
 
     const participants = await CommentHistory.findAll({  // 게시글 참여자 조회(중복 제거)
       where: { article_id },


### PR DESCRIPTION
알림 기능 수정했습니다.
test까지 완료했습니다.

댓글 삭제 시 알림 문제는 추후 수정하겠습니다.
(A 사용자의 첫 번째 댓글이  'comment_history'에 추가되고, 이후 댓글을 달았을 때는 'comment_history'에 추가 되지 않음 
-> 첫 번째 댓글을 지우면 'CASCADE'이기에 'comment_history'테이블에서 삭제되고 A는 알림을 못 받는 상황)

